### PR TITLE
Changed lab 2 - question 4b testcases to unicode strings.

### DIFF
--- a/ML_lab2_word_count_student.ipynb
+++ b/ML_lab2_word_count_student.ipynb
@@ -608,9 +608,9 @@
     "        str: The cleaned up string.\n",
     "    \"\"\"\n",
     "    <FILL IN>\n",
-    "print removePunctuation('Hi, you!')\n",
-    "print removePunctuation(' No under_score!')\n",
-    "print removePunctuation(' *      Remove punctuation then spaces  * ')"
+    "print removePunctuation(u'Hi, you!')\n",
+    "print removePunctuation(u' No under_score!')\n",
+    "print removePunctuation(u' *      Remove punctuation then spaces  * ')"
    ]
   },
   {
@@ -622,8 +622,8 @@
    "outputs": [],
    "source": [
     "# TEST Capitalization and punctuation (4b)\n",
-    "Test.assertEquals(removePunctuation(\" The Elephant's 4 cats. \"),\n",
-    "                  'the elephants 4 cats',\n",
+    "Test.assertEquals(removePunctuation(u\" The Elephant's 4 cats. \"),\n",
+    "                  u'the elephants 4 cats',\n",
     "                  'incorrect definition for removePunctuation function')"
    ]
   },


### PR DESCRIPTION
The RDD the student specified 'removePunctuation()' function will be used on contains unicode strings.
This test (4b) used default type strings, causing implementations of removePunctuation that use '.translate()' to pass this test.
However '.translate()' does not behave well for unicode strings, which cause cryptic errors later down the line (4c).
Aditionally positive test results for 4b wil confuse students debugging errors at 4c.
Changing the testcases to unicode strings better guides students towards using the regular expressions (re) module for answering question 4b.
