### PR TITLE
Fixed small semantic issue in Vis. 3

### DIFF
--- a/cs120_lab2_linear_regression_df.py
+++ b/cs120_lab2_linear_regression_df.py
@@ -524,7 +524,7 @@ predictions = np.asarray(parsed_val_data_df
                          .collect())
 error = np.asarray(parsed_val_data_df
                    .rdd
-                   .map(lambda lp: (average_train_year, lp.label))
+                   .map(lambda lp: (lp.label, average_train_year))
                    .map(lambda (l, p): squared_error(l, p))
                    .collect())
 norm = Normalize()


### PR DESCRIPTION
Made sure `lambda` arguments `l` and `p` correspond to `lp.label` and
`average_train_year`, respectively.
